### PR TITLE
ts-nameof issue #18 - toArray implementation

### DIFF
--- a/packages/ts-nameof.macro/ts-nameof.macro.d.ts
+++ b/packages/ts-nameof.macro/ts-nameof.macro.d.ts
@@ -5,6 +5,8 @@ declare module "ts-nameof.macro" {
         function full<T>(periodIndex?: number): string;
         function full<T>(func: (obj: T) => void, periodIndex?: number): string;
         function full(obj: any, periodIndex?: number): string;
+        function toArray<T>(func: (obj: T) => any[]): string[];
+        function toArray(...args: any[]): string[];
     }
 
     export default nameof;

--- a/packages/ts-nameof/src/text/replaceInText.ts
+++ b/packages/ts-nameof/src/text/replaceInText.ts
@@ -1,6 +1,8 @@
 ﻿import * as ts from "typescript";
 import { visitNode } from "../external/transforms-ts";
 
+const printer = ts.createPrinter();
+
 export function replaceInText(fileName: string, fileText: string): { fileText?: string; replaced: boolean; } {
     // unofficial pre-2.0 backwards compatibility for this method
     if (arguments.length === 1) {
@@ -27,7 +29,7 @@ export function replaceInText(fileName: string, fileText: string): { fileText?: 
 
         for (const transform of transformations) {
             finalText += fileText.substring(lastPos, transform.start);
-            finalText += `"${transform.text.replace(/\"/g, `\\"`)}"`;
+            finalText += transform.text;
             lastPos = transform.end;
         }
 
@@ -63,7 +65,7 @@ export function replaceInText(fileName: string, fileText: string): { fileText?: 
                 transformations.push({
                     start: nodeStart,
                     end: node.end,
-                    text: (resultNode as ts.StringLiteral).text
+                    text: printer.printNode(ts.EmitHint.Unspecified, resultNode, sourceFile)
                 });
             }
         }

--- a/packages/ts-nameof/ts-nameof.d.ts
+++ b/packages/ts-nameof/ts-nameof.d.ts
@@ -20,4 +20,6 @@ declare namespace nameof {
     function full<T>(periodIndex?: number): string;
     function full<T>(func: (obj: T) => void, periodIndex?: number): string;
     function full(obj: any, periodIndex?: number): string;
+    function toArray<T>(func: (obj: T) => any[]): string[];
+    function toArray(...args: any[]): string[];
 }

--- a/shared/lib/global.d.ts
+++ b/shared/lib/global.d.ts
@@ -4,4 +4,6 @@ declare namespace nameof {
     function full<T>(periodIndex?: number): string;
     function full<T>(func: (obj: T) => void, periodIndex?: number): string;
     function full(obj: any, periodIndex?: number): string;
+    function toArray<T>(func: (obj: T) => any[]): string[];
+    function toArray(...args: any[]): string[];
 }

--- a/shared/lib/global.tests.ts
+++ b/shared/lib/global.tests.ts
@@ -7,39 +7,49 @@ namespace TestNamespace {
 }
 
 class TestClass {
-    prop: string;
+    prop1: string;
+    prop2: string;
 }
 
 // nameof tests
 nameof(TestClass);
 nameof<TestNamespace.TestType>();
-nameof<TestClass>(t => t.prop);
+nameof<TestClass>(t => t.prop1);
 
 // nameof.full tests
 const testInstance = new TestClass();
-nameof.full(testInstance.prop);
-nameof.full(testInstance.prop, 1);
+nameof.full(testInstance.prop1);
+nameof.full(testInstance.prop1, 1);
 nameof.full<TestNamespace.TestType>();
 nameof.full<TestNamespace.TestType>(1);
-nameof.full<TestClass>(t => t.prop);
-nameof.full<TestClass>(t => t.prop, 1);
+nameof.full<TestClass>(t => t.prop1);
+nameof.full<TestClass>(t => t.prop1, 1);
+
+// nameof.toArray tests
+nameof.toArray(testInstance.prop1);
+nameof.toArray(testInstance.prop1, testInstance.prop2);
+nameof.toArray<TestClass>(t => [t.prop1]);
 
 // reference type test
 const myObj = { test: "" };
 nameof(myObj);
 nameof.full(myObj);
+nameof.toArray(myObj);
 
 // primitive type test
 const myStr = "";
 nameof(myStr);
 nameof.full(myStr);
+nameof.toArray(myStr);
 
 // null test
 const nullTypedVar = null;
 nameof(nullTypedVar);
 nameof.full(nullTypedVar);
+nameof.toArray(nullTypedVar);
 
 // undefined test
 const undefinedTypedVar = undefined;
 nameof(undefinedTypedVar);
 nameof.full(undefinedTypedVar);
+nameof.toArray(undefinedTypedVar);

--- a/shared/tests-common/src/runCommonTests.ts
+++ b/shared/tests-common/src/runCommonTests.ts
@@ -292,6 +292,39 @@ export function runCommonTests(getTransformedText: (text: string) => string, opt
         });
     });
 
+    describe("toArray", () => {
+        it("should return an array of values when given a function that returns an array as input", () => {
+            runTest(`nameof.toArray<MyInterface>(o => [o.Prop1, o.Prop2, o.Prop3]);`, `["Prop1", "Prop2", "Prop3"];`);
+        });
+
+        it("should return an array of values when given multiple arguments", () => {
+            runTest(`nameof.toArray(myObject.Prop1, otherObject.Prop2);`, `["Prop1", "Prop2"];`);
+        });
+
+        it("should return an array with a single element if a non-function argument is passed", () => {
+            runTest(`nameof.toArray(myObject.Prop1);`, `["Prop1"];`);
+        });
+
+        it("should support nested nameof calls", () => {
+            runTest(`nameof.toArray(nameof.full(Some.Qualified.Name), Some.Qualified.Name);`, `["Some.Qualified.Name", "Name"];`);
+        });
+
+        it("should support a non-arrow function expression", () => {
+            runTest(`nameof.toArray<MyInterface>(function(o) { return [o.Prop1, o.Prop2]; });`, `["Prop1", "Prop2"];`);
+        });
+
+        it("should throw when the function argument does not return an array", () => {
+            runThrowTest(
+                `nameof.toArray<MyInterface>(o => o.Prop1);`,
+                "Unsupported toArray call expression, an array must be returned by the provided function: nameof.toArray<MyInterface>((o) => o.Prop1)"
+            );
+        });
+
+        it("should throw when no arguments are provided", () => {
+            runThrowTest(`nameof.toArray<MyInterface>();`, "Unable to parse call expression, no arguments provided: nameof.toArray<MyInterface>()");
+        });
+    });
+
     describe("general", () => {
         it("should error when specifying a different nameof property", () => {
             runThrowTest(`nameof.nonExistent()`, "Unsupported nameof call expression with property 'nonExistent': nameof.nonExistent()");

--- a/shared/transforms-babel/src/transform.ts
+++ b/shared/transforms-babel/src/transform.ts
@@ -6,12 +6,12 @@ import * as common from "./external/transforms-common";
  * Transforms a common node to a Babel node.
  * @param node Common node to be transformed.
  */
-export function transform(t: typeof babelTypes, node: common.Node) {
+export function transform(t: typeof babelTypes, node: common.Node): babelTypes.StringLiteral | babelTypes.ArrayExpression {
     switch (node.kind) {
         case "StringLiteral":
             return t.stringLiteral(node.value);
         case "ArrayLiteral":
-            return throwError("Not implemented transform: ArrayLiteral.");
+            return t.arrayExpression(node.elements.map(element => transform(t, element)));
         default:
             return throwError(`Unsupported node kind: ${node.kind}`);
     }

--- a/shared/transforms-ts/src/parse.ts
+++ b/shared/transforms-ts/src/parse.ts
@@ -61,6 +61,8 @@ export function parse(parsingNode: ts.Node, sourceFile: ts.SourceFile) {
             return parseNumeric(node);
         if (ts.isStringLiteral(node))
             return parseStringLiteral(node);
+        if (ts.isArrayLiteralExpression(node))
+            return parseArrayLiteralExpression(node);
         if (ts.isIdentifier(node))
             return parseIdentifier(node);
         if (ts.isImportTypeNode(node))
@@ -70,6 +72,11 @@ export function parse(parsingNode: ts.Node, sourceFile: ts.SourceFile) {
         if (node.kind === ts.SyntaxKind.ThisKeyword)
             return common.createIdentifierNode("this");
         return throwError(`Unhandled node kind (${node.kind}) in text: ${getNodeText(node)} (Please open an issue if you believe this should be supported.)`);
+    }
+
+    function parseArrayLiteralExpression(node: ts.ArrayLiteralExpression) {
+        const elements = node.elements.map(element => parseCommonNode(element));
+        return common.createArrayLiteralNode(elements);
     }
 
     function parsePropertyAccessExpression(node: ts.PropertyAccessExpression) {

--- a/shared/transforms-ts/src/transform.ts
+++ b/shared/transforms-ts/src/transform.ts
@@ -6,12 +6,12 @@ import * as common from "./external/transforms-common";
  * Transforms a common node to a TypeScript compiler node.
  * @param node Common node to be transformed.
  */
-export function transform(node: common.Node) {
+export function transform(node: common.Node): ts.StringLiteral | ts.ArrayLiteralExpression {
     switch (node.kind) {
         case "StringLiteral":
             return ts.createLiteral(node.value);
         case "ArrayLiteral":
-            return throwError("Not implemented transform: ArrayLiteral.");
+            return ts.createArrayLiteral(node.elements.map(element => transform(element)));
         default:
             return throwError(`Unsupported node kind: ${node.kind}`);
     }


### PR DESCRIPTION
Implements the following signatures:

```ts
function toArray<T>(func: (obj: T) => any[]): string[];
function toArray(...args: any[]): string[];
```