### PR TITLE
fix: Add dist/tests to .npmignore

### DIFF
--- a/packages/transforms-ts/.npmignore
+++ b/packages/transforms-ts/.npmignore
@@ -1,6 +1,7 @@
 tsconfig.json
 tsconfig.tsbuildinfo
 src
+dist/tests
 coverage
 .nyc_output
 yarn-error.log


### PR DESCRIPTION
I noticed that `tests` was being compiled & published in the `transforms-ts` package, so I added the folder to `.npmignore` :)